### PR TITLE
install patch package and cross env

### DIFF
--- a/.github/workflows/deploy-boba.yml
+++ b/.github/workflows/deploy-boba.yml
@@ -61,6 +61,8 @@ jobs:
           # This approach is taken from https://github.com/yarnpkg/yarn/issues/7212#issuecomment-506155894 to fix the issue
           # Another approach is to install with flag --network-concurrency 1, but this will make the installation pretty slow (default value is 8)
           mkdir .yarncache
+          yarn add patch-package
+          yarn add cross-env
           yarn install --cache-folder ./.yarncache --frozen-lockfile
           rm -rf .yarncache
           yarn cache clean
@@ -81,4 +83,3 @@ jobs:
       - name: 'Deploy to S3: prod'
         working-directory: ./build
         run: aws s3 sync . s3://${{ env.S3_BUCKET }} --delete && aws cloudfront create-invalidation --distribution-id {{ env.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
-


### PR DESCRIPTION
```
[4/4] Building fresh packages...
$ patch-package && yarn generate-types
/bin/sh: 1: patch-package: not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 127.
```